### PR TITLE
Fix for "./xfce-test pull" from master branch

### DIFF
--- a/xfce-test
+++ b/xfce-test
@@ -197,7 +197,7 @@ MODES_FOR_CASE="+($MODES_FOR_CASE)"
 if [ -z $TAG ]; then
   if is_my_git; then
     TAG=$(git rev-parse --abbrev-ref HEAD 2>/dev/null|tr '/' '_')
-    if [[ $TAG == "last_tag" ]]; then
+    if [[ $TAG == "last_tag" ]] || [[ $TAG == "master" ]]; then
         TAG=latest
     fi
   else


### PR DESCRIPTION
After trying "./xfce-test pull" from the master branch, I was getting the following error:

`Error response from daemon: manifest for schuellerf/xfce-test:master not found: manifest unknown: manifest unknown
Execution took 4 seconds`

This pull request will help to fix this issue.